### PR TITLE
Produce single executable for release

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -26,10 +26,27 @@ jobs:
       run: dotnet build --no-restore -c release
     - name: Test
       run: dotnet test --no-build --verbosity normal
+    - name: Small
+      run: >
+        dotnet publish -c release -o .dist/small --no-self-contained 
+        -p:PublishSingleFile=true -p:DebugType=embedded -p:PublishTrimmed=false 
+        -p:EnableCompressionInSingleFile=false --use-current-runtime
+    - name: Portable
+      run: >
+        dotnet publish -c release -o .dist/portable --self-contained 
+        -p:PublishSingleFile=true -p:DebugType=embedded -p:PublishTrimmed=true 
+        -p:EnableCompressionInSingleFile=true --use-current-runtime
+
     - uses: actions/upload-artifact@v3
       with:
         name: Elib2Ebook-${{ matrix.os }}
-        path: ${{ github.workspace }}/Elib2Ebook/bin/Release/net6.0/
+        path: ${{ github.workspace }}/.dist/small
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: Elib2Ebook-${{ matrix.os }}-portable
+        path: ${{ github.workspace }}/.dist/portable
+    
   release:
     needs: build
     runs-on: ubuntu-latest
@@ -66,7 +83,12 @@ jobs:
         with:
           name: Elib2Ebook-ubuntu-latest
           path: ${{ github.workspace }}/linux
-          
+      - name: download-artifact-ubuntu-portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Elib2Ebook-ubuntu-latest-portable
+          path: ${{ github.workspace }}/linux-portable      
           
       - name: download-artifact-windows
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
@@ -74,6 +96,12 @@ jobs:
         with:
           name: Elib2Ebook-windows-latest
           path: ${{ github.workspace }}/windows
+      - name: download-artifact-windows-portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Elib2Ebook-windows-latest-portable
+          path: ${{ github.workspace }}/windows-portable
           
       - name: download-artifact-macos
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
@@ -81,6 +109,12 @@ jobs:
         with:
           name: Elib2Ebook-macos-latest
           path: ${{ github.workspace }}/macos
+      - name: download-artifact-macos-portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/download-artifact@v3
+        with:
+          name: Elib2Ebook-macos-latest-portable
+          path: ${{ github.workspace }}/macos-portable
                   
       - name: Install zip
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
@@ -88,18 +122,31 @@ jobs:
         
       - name: Zip output
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
-        run: zip -qq -r Elib2Ebook-Linux.zip linux
-        working-directory: ${{ github.workspace }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Linux.zip .
+        working-directory: ${{ github.workspace }}/linux
+      - name: Zip output
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Linux-portable.zip .
+        working-directory: ${{ github.workspace }}/linux-portable
           
       - name: Zip output
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
-        run: zip -qq -r Elib2Ebook-Windows.zip windows
-        working-directory: ${{ github.workspace }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Windows.zip .
+        working-directory: ${{ github.workspace }}/windows          
+      - name: Zip output
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Windows-portable.zip .
+        working-directory: ${{ github.workspace }}/windows-portable
         
       - name: Zip output
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
-        run: zip -qq -r Elib2Ebook-Macos.zip macos
-        working-directory: ${{ github.workspace }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Macos.zip .
+        working-directory: ${{ github.workspace }}/macos
+                 
+      - name: Zip output
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        run: zip -qq -x "*.pdb" -r ../Elib2Ebook-Macos-portable.zip .
+        working-directory: ${{ github.workspace }}/macos-portable
                  
       - name: upload linux artifact
         if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
@@ -132,4 +179,37 @@ jobs:
           upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: Elib2Ebook-Macos.zip
           asset_name: Elib2Ebook-Macos.zip
+          asset_content_type: application/zip
+
+      - name: upload linux artifact portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Elib2Ebook-Linux-portable.zip
+          asset_name: Elib2Ebook-Linux-portable.zip
+          asset_content_type: application/zip
+
+      - name: upload windows artifact portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Elib2Ebook-Windows-portable.zip
+          asset_name: Elib2Ebook-Windows-portable.zip
+          asset_content_type: application/zip
+
+      - name: upload macos artifact portable
+        if: ${{ steps.last_release.outputs.tag_name != steps.get-version.outputs.version }}
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: Elib2Ebook-Macos-portable.zip
+          asset_name: Elib2Ebook-Macos-portable.zip
           asset_content_type: application/zip

--- a/.gitignore
+++ b/.gitignore
@@ -38,4 +38,5 @@ Code/\.idea/\.idea\.AllIn/\.idea/
 .idea
 */.idea/*
 **/logs/**
-
+.dist
+.vs

--- a/Elib2Ebook/Elib2Ebook.csproj
+++ b/Elib2Ebook/Elib2Ebook.csproj
@@ -7,35 +7,30 @@
         <LangVersion>10</LangVersion>
         <PackageId>Elib2Ebook</PackageId>
         <Version>1.30.7</Version>
+        <GenerateEmbeddedFilesManifest>true</GenerateEmbeddedFilesManifest>
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="CommandLineParser" Version="2.9.1" />
-      <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
-      <PackageReference Include="HtmlAgilityPack.CssSelectors.NetCore" Version="1.2.1" />
-      <PackageReference Include="OAuth.DotNetCore" Version="3.0.1" />
-      <PackageReference Include="TempFolder" Version="1.0.0" />
+        <PackageReference Include="CommandLineParser" Version="2.9.1"/>
+        <PackageReference Include="HtmlAgilityPack" Version="1.11.46"/>
+        <PackageReference Include="HtmlAgilityPack.CssSelectors.NetCore" Version="1.2.1"/>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Composite" Version="6.0.0"/>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Embedded" Version="6.0.11"/>
+        <PackageReference Include="Microsoft.Extensions.FileProviders.Physical" Version="6.0.0"/>
+        <PackageReference Include="OAuth.DotNetCore" Version="3.0.1"/>
+        <PackageReference Include="TempFolder" Version="1.0.0"/>
     </ItemGroup>
 
     <ItemGroup>
-      <None Update="Patterns\ChapterPattern.xhtml">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="Patterns\stylesheet.css">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="Patterns\Roboto-Regular.ttf">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
-      <None Update="Patterns\Roboto-Italic.ttf">
-        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-      </None>
+        <EmbeddedResource Include="Patterns\**\*.*">
+            <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+        </EmbeddedResource>
     </ItemGroup>
 
     <ItemGroup>
-      <Reference Include="EpubSharp, Version=1.1.5.13, Culture=neutral, PublicKeyToken=null">
-        <HintPath>External\EpubSharp.dll</HintPath>
-      </Reference>
+        <Reference Include="EpubSharp, Version=1.1.5.13, Culture=neutral, PublicKeyToken=null">
+            <HintPath>External\EpubSharp.dll</HintPath>
+        </Reference>
     </ItemGroup>
 
 </Project>

--- a/Elib2Ebook/Extensions/FileProviderExtensions.cs
+++ b/Elib2Ebook/Extensions/FileProviderExtensions.cs
@@ -1,0 +1,37 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Enumeration;
+using System.Linq;
+using Microsoft.Extensions.FileProviders;
+
+namespace Elib2Ebook.Extensions;
+
+public static class FileProviderExtensions
+{
+    public static byte[] ReadAllBytes(this IFileInfo fileInfo)
+    {
+        using var ms = new MemoryStream();
+        using var source = fileInfo.CreateReadStream();
+        source.CopyTo(ms);
+        return ms.ToArray();
+    }
+    
+    public static string ReadAllText(this IFileInfo fileInfo)
+    {
+        using var source = fileInfo.CreateReadStream();
+        using var sr = new StreamReader(source);
+        return sr.ReadToEnd();
+    }
+
+    public static string ReadAllText(this IFileProvider fileProvider, string path)
+    {
+        var file = fileProvider.GetFileInfo(path);
+        return file.ReadAllText();
+    }
+    
+    public static IEnumerable<IFileInfo> GetFiles(this IFileProvider fileProvider, string directory, string searchPattern)
+    {
+        return fileProvider.GetDirectoryContents(directory)
+            .Where(file => FileSystemName.MatchesSimpleExpression(searchPattern, file.Name));
+    }
+}

--- a/Elib2Ebook/Logic/Builders/BuilderBase.cs
+++ b/Elib2Ebook/Logic/Builders/BuilderBase.cs
@@ -7,7 +7,8 @@ using Elib2Ebook.Types.Book;
 
 namespace Elib2Ebook.Logic.Builders; 
 
-public abstract class BuilderBase {
+public abstract class BuilderBase
+{
     /// <summary>
     /// Добавление автора книги
     /// </summary>

--- a/Elib2Ebook/Logic/Builders/EpubBuilder.cs
+++ b/Elib2Ebook/Logic/Builders/EpubBuilder.cs
@@ -36,7 +36,8 @@ public class EpubBuilder : BuilderBase {
     /// <param name="decodeText">Раскодированный текст</param>
     /// <returns></returns>
     private string ApplyPattern(string title, string decodeText) {
-        return _pattern.Replace("{title}", title.CleanInvalidXmlChars().ReplaceNewLine()).Replace("{body}", decodeText.HtmlDecode().CleanInvalidXmlChars()).AsXHtmlDoc().AsString();
+        return _pattern.Replace("{title}", title.CleanInvalidXmlChars().ReplaceNewLine()).Replace("{body}", 
+            decodeText.HtmlDecode().CleanInvalidXmlChars()).AsXHtmlDoc().AsString();
     }
 
     /// <summary>
@@ -91,17 +92,18 @@ public class EpubBuilder : BuilderBase {
     /// <param name="searchPattern">Шаблон поиска файлов</param>
     /// <returns></returns>
     public override BuilderBase WithFiles(string directory, string searchPattern) {
-        foreach (var file in Directory.GetFiles(directory, searchPattern)) {
-            var fileName = Path.GetFileName(file);
-            var type = file.EndsWith(".ttf") ? 
+        foreach (var file in FileProvider.Instance.GetFiles(directory, searchPattern))
+        {
+            var fileName = Path.GetFileName(file.Name);
+            var type = file.Name.EndsWith(".ttf") ? 
                 EpubContentType.FontTruetype : 
-                file.EndsWith(".css") ? 
+                file.Name.EndsWith(".css") ? 
                     EpubContentType.Css : 
                     throw new Exception($"Неизвестный тип файла {fileName}");
             
-            _writer.AddFile(fileName, File.ReadAllBytes(file), type);
+            _writer.AddFile(fileName, file.ReadAllBytes(), type);
         }
-            
+      
         return this;
     }
 

--- a/Elib2Ebook/Logic/FileProvider.cs
+++ b/Elib2Ebook/Logic/FileProvider.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Microsoft.Extensions.FileProviders;
+
+namespace Elib2Ebook.Logic;
+
+public class FileProvider
+{
+    public static readonly IFileProvider Instance;
+
+    static FileProvider()
+    {
+        var cwd = AppDomain.CurrentDomain.BaseDirectory;
+        var providers = new List<IFileProvider>();
+        var patternsDirectory = Path.Combine(cwd);
+
+        if (Directory.Exists(patternsDirectory))
+        {
+            providers.Add(new PhysicalFileProvider(patternsDirectory));
+        }
+        
+        providers.Add(new ManifestEmbeddedFileProvider(Assembly.GetExecutingAssembly()));
+
+        Instance = new CompositeFileProvider(providers);
+    }
+}

--- a/Elib2Ebook/Program.cs
+++ b/Elib2Ebook/Program.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
@@ -9,6 +8,7 @@ using System.Threading.Tasks;
 using CommandLine;
 using Elib2Ebook.Configs;
 using Elib2Ebook.Extensions;
+using Elib2Ebook.Logic;
 using Elib2Ebook.Logic.Builders;
 using Elib2Ebook.Logic.Getters;
 using TempFolder;
@@ -65,7 +65,7 @@ internal static class Program {
     private static BuilderBase GetBuilder(string format) {
         return format.Trim().ToLower() switch {
             "fb2" => Fb2Builder.Create(),
-            "epub" => EpubBuilder.Create(File.ReadAllText("Patterns/ChapterPattern.xhtml")),
+            "epub" => EpubBuilder.Create(FileProvider.Instance.ReadAllText("Patterns/ChapterPattern.xhtml")),
             "json" => JsonBuilder.Create(),
             "cbz" => CbzBuilder.Create(),
             _ => throw new ArgumentException("Неизвестный формат", nameof(format))


### PR DESCRIPTION
Прежде всего спасибо за тулу. Очень выручает. Я не для того покупал читалку, чтобы читать книги с сайта.

Небольшие правки в коде, чтобы на выхлопе был один исполняемый файл без остального мусора, без потери функционала.

Также добавлены в релиз `portable` версии, которым не нужен установленный на компьютере net6 рантайм. Удобно тем, у кого политики на компьютере не позволяют что-либо устанавливать,

![image](https://user-images.githubusercontent.com/118516/202915430-f69659a8-2e9c-4f09-9d5d-9eaf3149d251.png)

Тут https://github.com/alfeg/Elib2Ebook/releases/tag/1.30.5 можно глянуть какой выходит результат в гитхаб релизе
