### PR TITLE
Исправления ranobelib

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ dist
 .vs
 .vscode/launch.json
 .vscode/tasks.json
+
+.dotnet/

--- a/Core/Extensions/HttpClientExtensions.cs
+++ b/Core/Extensions/HttpClientExtensions.cs
@@ -24,6 +24,11 @@ public static class HttpClientExtensions {
                 var response = await client.GetAsync(url);
 
                 if (response.StatusCode != HttpStatusCode.OK) {
+                    if (i == MAX_TRY_COUNT - 1) {
+                        return response;
+                    }
+
+                    response.Dispose();
                     await Task.Delay(GetTimeout(errorTimeout));
                     continue;
                 }
@@ -46,10 +51,15 @@ public static class HttpClientExtensions {
         Exception lastEx = null;
         
         for (var i = 0; i < MAX_TRY_COUNT; i++) {
-            try { 
+            try {
                 var response = await client.SendAsync(message());
 
                 if (response.StatusCode != HttpStatusCode.OK) {
+                    if (i == MAX_TRY_COUNT - 1) {
+                        return response;
+                    }
+
+                    response.Dispose();
                     await Task.Delay(GetTimeout(errorTimeout));
                     continue;
                 }

--- a/Core/Extensions/HttpClientExtensions.cs
+++ b/Core/Extensions/HttpClientExtensions.cs
@@ -1,8 +1,10 @@
 using System;
+using System.IO;
 using System.Net;
 using System.Net.Http;
 using System.Net.Http.Json;
 using System.Text;
+using System.Text.Json;
 using System.Threading.Tasks;
 using HtmlAgilityPack;
 
@@ -115,11 +117,65 @@ public static class HttpClientExtensions {
     
     public static async Task<T> GetFromJsonWithTriesAsync<T>(this HttpClient client, Uri url, TimeSpan errorTimeout = default) {
         using var response = await client.GetWithTriesAsync(url, errorTimeout);
-        return await response.Content.ReadFromJsonAsync<T>();
+        if (response == default) {
+            throw new Exception($"Не удалось получить ответ от {url}");
+        }
+
+        if (response.StatusCode != HttpStatusCode.OK) {
+            var errorBody = await SafeReadAsStringAsync(response.Content);
+            throw new Exception($"Ошибка запроса {url}. Код {(int)response.StatusCode} ({response.StatusCode}).{FormatSnippet(errorBody)}");
+        }
+
+        await using var stream = await response.Content.ReadAsStreamAsync();
+        using var memoryStream = new MemoryStream();
+        await stream.CopyToAsync(memoryStream);
+
+        var payload = Encoding.UTF8.GetString(memoryStream.ToArray());
+        if (string.IsNullOrWhiteSpace(payload)) {
+            throw new Exception($"Ответ {url} пустой");
+        }
+
+        if (LooksLikeHtml(payload)) {
+            throw new Exception($"Сайт вернул HTML вместо JSON по адресу {url}. Возможно сработала защита (DDoS-Guard). Попробуйте увеличить параметры --delay/--timeout или настроить --flare.");
+        }
+
+        try {
+            return JsonSerializer.Deserialize<T>(payload, new JsonSerializerOptions(JsonSerializerDefaults.Web)) ?? throw new Exception($"Сайт вернул пустой JSON по адресу {url}");
+        } catch (JsonException ex) {
+            throw new Exception($"Не удалось разобрать JSON ответа {url}. {ex.Message}. {FormatSnippet(payload)}", ex);
+        }
     }
-    
+
     public static async Task<HtmlDocument> PostHtmlDocWithTriesAsync(this HttpClient client, Uri url, HttpContent content, Encoding encoding = null) {
         using var response = await client.PostWithTriesAsync(url, content);
         return await response.Content.ReadAsStreamAsync().ContinueWith(t => t.Result.AsHtmlDoc(encoding));
+    }
+
+    private static async Task<string> SafeReadAsStringAsync(HttpContent content) {
+        try {
+            return await content.ReadAsStringAsync();
+        } catch {
+            return string.Empty;
+        }
+    }
+
+    private static bool LooksLikeHtml(string value) {
+        return value.TrimStart().StartsWith("<", StringComparison.Ordinal);
+    }
+
+    private static string FormatSnippet(string value, int maxLength = 300) {
+        if (string.IsNullOrWhiteSpace(value)) {
+            return string.Empty;
+        }
+
+        var trimmed = value.Trim();
+        if (LooksLikeHtml(trimmed)) {
+            return string.Empty;
+        }
+        if (trimmed.Length > maxLength) {
+            trimmed = trimmed[..maxLength] + "…";
+        }
+
+        return $" Ответ сервера: {trimmed}";
     }
 }

--- a/Core/Logic/Getters/LibSocial/HentaiLibGetter.cs
+++ b/Core/Logic/Getters/LibSocial/HentaiLibGetter.cs
@@ -7,4 +7,6 @@ public class HentaiLibGetter(BookGetterConfig config) : MangaLibGetterBase(confi
     protected override Uri ImagesHost => new("https://img3.imglib.info/");
     
     protected override Uri SystemUrl => new("https://hentailib.me/");
+
+    protected override int SiteId => 4;
 }

--- a/Core/Logic/Getters/LibSocial/MangaLibGetter.cs
+++ b/Core/Logic/Getters/LibSocial/MangaLibGetter.cs
@@ -7,4 +7,6 @@ public class MangaLibGetter(BookGetterConfig config) : MangaLibGetterBase(config
     protected override Uri ImagesHost => new("https://img33.imgslib.link/");
 
     protected override Uri SystemUrl => new("https://mangalib.me/");
+
+    protected override int SiteId => 1;
 }

--- a/Core/Logic/Getters/LibSocial/MangaLibOrgGetter.cs
+++ b/Core/Logic/Getters/LibSocial/MangaLibOrgGetter.cs
@@ -7,4 +7,6 @@ public class MangaLibOrgGetter(BookGetterConfig config) : MangaLibGetterBase(con
     protected override Uri ImagesHost => new("https://img33.imgslib.link/");
 
     protected override Uri SystemUrl => new("https://mangalib.org/");
+
+    protected override int SiteId => 1;
 }

--- a/Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs
+++ b/Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs
@@ -198,11 +198,7 @@ public abstract class NewLibSocialGetterBase(BookGetterConfig config) : GetterBa
         }
 
         if (response.StatusCode != HttpStatusCode.OK) {
-            var errorBody = await response.Content.ReadAsStringAsync();
-            var snippet = string.IsNullOrWhiteSpace(errorBody)
-                ? string.Empty
-                : $" Ответ сервера: {TrimForLog(errorBody)}";
-            throw new Exception($"Ошибка загрузки информации о книге. Код {(int)response.StatusCode} ({response.StatusCode}).{snippet}");
+            throw new Exception($"Ошибка загрузки информации о книге. Код {(int)response.StatusCode} ({response.StatusCode}).");
         }
 
         return await response.Content.ReadFromJsonAsync<RanobeLibBookDetails>();
@@ -219,11 +215,7 @@ public abstract class NewLibSocialGetterBase(BookGetterConfig config) : GetterBa
         }
 
         if (response.StatusCode != HttpStatusCode.OK) {
-            var errorBody = await response.Content.ReadAsStringAsync();
-            var snippet = string.IsNullOrWhiteSpace(errorBody)
-                ? string.Empty
-                : $" Ответ сервера: {TrimForLog(errorBody)}";
-            throw new Exception($"Ошибка загрузки оглавления. Код {(int)response.StatusCode} ({response.StatusCode}).{snippet}");
+            throw new Exception($"Ошибка загрузки оглавления. Код {(int)response.StatusCode} ({response.StatusCode}).");
         }
 
         var result = await response.Content.ReadFromJsonAsync<SocialLibBookChapters>().ContinueWith(t => t.Result.Chapters);

--- a/Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs
+++ b/Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs
@@ -31,6 +31,25 @@ public abstract class NewLibSocialGetterBase(BookGetterConfig config) : GetterBa
     private const string ALPHABET_BASE = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789";
     private const string ALPHABET_CHALLENGE = ALPHABET_BASE + "-_";
 
+    protected abstract int SiteId { get; }
+
+    public override async Task Init() {
+        await base.Init();
+
+        Config.Client.DefaultRequestHeaders.Remove("Site-Id");
+        Config.Client.DefaultRequestHeaders.Add("Site-Id", SiteId.ToString());
+
+        try {
+            var timeZoneId = TimeZoneInfo.Local.Id;
+            Config.Client.DefaultRequestHeaders.Remove("Client-Time-Zone");
+            Config.Client.DefaultRequestHeaders.Add("Client-Time-Zone", timeZoneId);
+        } catch (TimeZoneNotFoundException) {
+            // Игнорируем: таймзона влияет только на аналитические метрики сайта
+        } catch (InvalidTimeZoneException) {
+            // Игнорируем: таймзона влияет только на аналитические метрики сайта
+        }
+    }
+
     private static string TrimForLog(string value, int maxLength = 300) {
         if (string.IsNullOrWhiteSpace(value)) {
             return string.Empty;

--- a/Core/Logic/Getters/LibSocial/RanobeLibGetter.cs
+++ b/Core/Logic/Getters/LibSocial/RanobeLibGetter.cs
@@ -14,6 +14,8 @@ namespace Core.Logic.Getters.LibSocial;
 
 public class RanobeLibGetter(BookGetterConfig config) : NewLibSocialGetterBase(config) {
     protected override Uri SystemUrl => new("https://ranobelib.me/");
+
+    protected override int SiteId => 3;
     
     private static readonly Dictionary<string, string> RecursiveTag = new() {
         { "paragraph", "p" },

--- a/Core/Logic/Getters/LibSocial/SlashLibGetter.cs
+++ b/Core/Logic/Getters/LibSocial/SlashLibGetter.cs
@@ -7,4 +7,6 @@ public class SlashLibGetter : MangaLibGetter {
     public SlashLibGetter(BookGetterConfig config) : base(config) { }
     
     protected override Uri SystemUrl => new("https://v2.slashlib.me/");
+
+    protected override int SiteId => 2;
 }

--- a/Elib2EbookCli/Program.cs
+++ b/Elib2EbookCli/Program.cs
@@ -46,8 +46,14 @@ internal static class Program {
             .WithParsedAsync(async options => {
                 using var getterConfig = BookGetterConfig.GetDefault(options, logger); 
                 using var getter = GetterProvider.Get(getterConfig, options.Url.First().AsUri());
-                await getter.Init();
-                await getter.Authorize();
+
+                try {
+                    await getter.Init();
+                    await getter.Authorize();
+                } catch (Exception ex) {
+                    logger.LogInformation($"Ошибка авторизации или инициализации. {ex.Message}");
+                    return;
+                }
 
                 foreach (var url in options.Url) {
                     logger.LogInformation($"Начинаю генерацию книги {url.CoverQuotes()}");


### PR DESCRIPTION
## Контекст
- CLI падал при скачивании  с `NullReferenceException`. Причина — Ranobelib API стабильно отвечает `HTTP 404` JSON-ом `{"data":{"toast":{"type":"silent","message":"Not Found"}}}`, а `HttpClientExtensions.GetWithTriesAsync` возвращал `null`, что приводило к разыменованию `response`.
- При попытке авторизации с неверным логином/паролем выводилось «Успешно авторизовались», а затем приложение падало с необработанным исключением и стеком.

## Что изменено

### 1. Заголовки Site-Id и Client-Time-Zone для API lib.social
- `Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs`
  - Добавлен `SiteId` и переопределение `Init`, которое выставляет обязательные заголовки `Site-Id` и `Client-Time-Zone` (со значениями, соответствующими текущему сайту и таймзоне машины).
- `Core/Logic/Getters/LibSocial/{MangaLibGetter,MangaLibOrgGetter,SlashLibGetter,HentaiLibGetter,RanobeLibGetter}.cs`
  - Для каждого сайта задан корректный `SiteId` (Manga=1, Slash=2, Ranobe=3, Hentai=4), чтобы API перестало отвечать `404`.

### 2. Корректная работа с HTTP-ответами
- `Core/Extensions/HttpClientExtensions.cs`
  - `GetWithTriesAsync` и `SendWithTriesAsync` теперь возвращают последний полученный `HttpResponseMessage`, даже если статус не 200. Это позволяет вызывающей стороне увидеть реальный код и тело ответа.
  - Добавлена очистка (Dispose) промежуточных ответов при повторных попытках.

### 3. Обработка ошибок Ranobelib API
- `Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs`
  - Добавлен хелпер `TrimForLog` для компактного вывода тела ответа (до 300 символов).
  - В `GetBookDetails`/`GetToc` добавлены проверки `response == default` и детализированные сообщения об ошибках с HTTP-кодом и фрагментом тела ответа.
  - В `Authorize`:
    - Проверяется наличие `_token` в форме логина, присутствие формы подтверждения OAuth, корректность `code` и успешность запроса access token.
    - При любом отклонении выбрасываются осмысленные исключения (с указанием возможных причин: неверные учётные данные, блокировка DDoS-Guard и т.п.).

### 4. Защита от HTML/500 ответов при загрузке глав
- `Core/Extensions/HttpClientExtensions.cs`
  - `GetFromJsonWithTriesAsync` теперь проверяет статус ответа, сохраняет тело, детектирует HTML (DDOS-Guard) и формирует понятное сообщение с советами по `--delay/--timeout/--flare`.
  - При ошибках JSON возвращается обрезанный сниппет ответа, чтобы понять, почему API не прислало данные.

### 5. Отлов reCAPTCHA/CSRF при авторизации lib.social
- `Core/Logic/Getters/LibSocial/NewLibSocialGetterBase.cs`
  - После отправки логина страница проверяется на наличие `.g-recaptcha`; если капча активна, выводим понятное сообщение с рекомендацией использовать `--flare`.
  - Код 419 от авторизации также транслируется в пояснение про капчу/просроченный токен.

### 6. Дружелюбное сообщение об ошибке авторизации
- `Elib2EbookCli/Program.cs`
  - Добавлен `try/catch` вокруг `getter.Init()` + `getter.Authorize()`. Теперь CLI выводит сообщение `"Ошибка авторизации или инициализации. …"` и завершает работу без стека вызовов.

## В итоге
- Если книга с ranobelib доступна без авторизации и не срабатывает ddos guard, скачивание через cli работает
- Авторизация не работает, потому что перманентно защищена капчей
- Добавлены более осмысленные сообщения об ошибках
- Но ddos guard всё равно иногда срабатывает с ошибкой 500 без деталей
- Web интерфейс работает и отображает новые тексты ошибок
- Другие сайты (manga, hentai и т.д.) -- нужно тестировать
